### PR TITLE
Fix Command-Tab interference in tabrywhere on macOS

### DIFF
--- a/tabrywhere/main.py
+++ b/tabrywhere/main.py
@@ -570,6 +570,16 @@ def callback(proxy, event_type, event, refcon):
 
         # Intercept ALL physical Tab events (including autorepeat)
         if keycode == KC_TAB:
+            # Check for modifier keys (Command, Option, Control, Shift)
+            flags = Quartz.CGEventGetFlags(event)
+            cmd_pressed = bool(flags & Quartz.kCGEventFlagMaskCommand)
+            opt_pressed = bool(flags & Quartz.kCGEventFlagMaskAlternate)
+            ctrl_pressed = bool(flags & Quartz.kCGEventFlagMaskControl)
+            
+            # Allow Command-Tab, Option-Tab, and Control-Tab to pass through
+            if cmd_pressed or opt_pressed or ctrl_pressed:
+                return event  # Let system handle app switching and other shortcuts
+            
             if event_type == Quartz.kCGEventKeyDown:
                 autorepeat = Quartz.CGEventGetIntegerValueField(event, Quartz.kCGKeyboardEventAutorepeat)
                 # Run handle_tab_down only on the first non-autorepeat, but always swallow


### PR DESCRIPTION
## Description
This PR fixes the issue where tabrywhere intercepts Command-Tab, preventing users from switching between applications on macOS.

## Problem
The event tap was capturing all Tab key events system-wide, including those with modifier keys like Command-Tab (⌘+Tab), which broke the native app switching functionality.

## Solution
Added modifier key detection in the callback function to allow Tab events with Command, Option, or Control modifiers to pass through to the system untouched.

## Changes
- Check for modifier key flags (Command, Option, Control) when Tab is pressed
- Pass through Tab events with these modifiers to the system
- Only intercept plain Tab key presses (without modifiers) for AI autocomplete

## Testing
- ✅ Command-Tab now works for app switching
- ✅ Option-Tab passes through to the system
- ✅ Control-Tab passes through to the system  
- ✅ Plain Tab (held) still triggers AI autocomplete

Fixes #2